### PR TITLE
Don't shadow variables

### DIFF
--- a/yahttp/cookie.hpp
+++ b/yahttp/cookie.hpp
@@ -66,7 +66,7 @@ namespace YaHTTP {
     } //<! key value pair parser
   
     void parseCookieHeader(const std::string &cookiestr) {
-      std::list<Cookie> cookies;
+      std::list<Cookie> lcookies;
       int cstate = 0; //cookiestate
       size_t pos,npos;
       pos = 0;
@@ -91,22 +91,22 @@ namespace YaHTTP {
           if (s == "expires") {
             DateTime dt;
             dt.parseCookie(value);
-            for(std::list<Cookie>::iterator i = cookies.begin(); i != cookies.end(); i++)
+            for(std::list<Cookie>::iterator i = lcookies.begin(); i != lcookies.end(); i++)
               i->expires = dt;
           } else if (s == "domain") {
-            for(std::list<Cookie>::iterator i = cookies.begin(); i != cookies.end(); i++)
+            for(std::list<Cookie>::iterator i = lcookies.begin(); i != lcookies.end(); i++)
               i->domain = value;
           } else if (s == "path") {
-            for(std::list<Cookie>::iterator i = cookies.begin(); i != cookies.end(); i++)
+            for(std::list<Cookie>::iterator i = lcookies.begin(); i != lcookies.end(); i++)
               i->path = value;
           }
         } else if (cookiestr.compare(pos, 8, "httpOnly")==0) {
           cstate = 1;
-          for(std::list<Cookie>::iterator i = cookies.begin(); i != cookies.end(); i++)
+          for(std::list<Cookie>::iterator i = lcookies.begin(); i != lcookies.end(); i++)
             i->httponly = true;
         } else if (cookiestr.compare(pos, 6, "secure")  ==0) {
           cstate = 1;
-          for(std::list<Cookie>::iterator i = cookies.begin(); i != cookies.end(); i++)
+          for(std::list<Cookie>::iterator i = lcookies.begin(); i != lcookies.end(); i++)
             i->secure = true;
         } else if (cstate == 0) { // expect cookie
           Cookie c;
@@ -123,7 +123,7 @@ namespace YaHTTP {
           keyValuePair(s, c.name, c.value);
           c.name = YaHTTP::Utility::decodeURL(c.name);
           c.value = YaHTTP::Utility::decodeURL(c.value);
-          cookies.push_back(c);
+          lcookies.push_back(c);
         } else if (cstate == 1) {
           // ignore crap
           break;
@@ -131,7 +131,7 @@ namespace YaHTTP {
       }
   
       // store cookies
-      for(std::list<Cookie>::iterator i = cookies.begin(); i != cookies.end(); i++) {
+      for(std::list<Cookie>::iterator i = lcookies.begin(); i != lcookies.end(); i++) {
         this->cookies[i->name] = *i;
       }
     }; //<! Parse multiple cookies from header 

--- a/yahttp/exception.hpp
+++ b/yahttp/exception.hpp
@@ -8,7 +8,7 @@ namespace YaHTTP {
   class Error: public std::exception {
   public:
     Error() {};
-    Error(const std::string& reason): reason(reason) {};
+    Error(const std::string& reason_): reason(reason_) {};
     virtual ~Error() throw() {};
 
     virtual const char* what() const throw()
@@ -21,7 +21,7 @@ namespace YaHTTP {
   class ParseError: public YaHTTP::Error {
   public:
     ParseError() {};
-    ParseError(const std::string& reason): Error(reason) {};
+    ParseError(const std::string& reason_): Error(reason_) {};
   };
 };
 

--- a/yahttp/reqresp.cpp
+++ b/yahttp/reqresp.cpp
@@ -61,17 +61,17 @@ namespace YaHTTP {
         }
       } else if (state == 1) {
         std::string key,value;
-        size_t pos;
+        size_t pos1;
         if (line.empty()) {
           chunked = (target->headers.find("transfer-encoding") != target->headers.end() && target->headers["transfer-encoding"] == "chunked");
           state = 2;
           break;
         }
         // split headers
-        if ((pos = line.find(": ")) == std::string::npos)
+        if ((pos1 = line.find(": ")) == std::string::npos)
           throw ParseError("Malformed header line");
-        key = line.substr(0, pos);
-        value = line.substr(pos+2);
+        key = line.substr(0, pos1);
+        value = line.substr(pos1+2);
         for(std::string::iterator it=key.begin(); it != key.end(); it++)
           if (std::isspace(*it))
             throw ParseError("Header key contains whitespace which is not allowed by RFC");
@@ -86,11 +86,11 @@ namespace YaHTTP {
         } else {
           if (key == "host" && target->kind == YAHTTP_TYPE_REQUEST) {
             // maybe it contains port?
-            if ((pos = value.find(":")) == std::string::npos) {
+            if ((pos1 = value.find(":")) == std::string::npos) {
               target->url.host = value;
             } else {
-              target->url.host = value.substr(0, pos);
-              target->url.port = ::atoi(value.substr(pos).c_str());
+              target->url.host = value.substr(0, pos1);
+              target->url.port = ::atoi(value.substr(pos1).c_str());
             }
           }
           if (target->headers.find(key) != target->headers.end()) {

--- a/yahttp/reqresp.hpp
+++ b/yahttp/reqresp.hpp
@@ -65,8 +65,8 @@ namespace YaHTTP {
     /* Simple sendfile renderer which streams file to ostream */
     class SendFileRender {
     public:
-      SendFileRender(const std::string& path) {
-        this->path = path;
+      SendFileRender(const std::string& path_) {
+        this->path = path_;
       };
   
       size_t operator()(const HTTPBase *doc __attribute__((unused)), std::ostream& os, bool chunked) const {
@@ -174,8 +174,8 @@ public:
     strstr_map_t& POST() { return postvars; }; //<! accessor for postvars
     strcookie_map_t& COOKIES() { return jar.cookies; }; //<! accessor for cookies
 
-    std::string versionStr(int version) const {
-      switch(version) {
+    std::string versionStr(int version_) const {
+      switch(version_) {
       case  9: return "0.9";
       case 10: return "1.0";
       case 11: return "1.1";
@@ -244,10 +244,10 @@ public:
       this->jar = rhs.jar;
       this->version = rhs.version;
     }
-    void setup(const std::string& method, const std::string& url) {
-      this->url.parse(url);
+    void setup(const std::string& method_, const std::string& url_) {
+      this->url.parse(url_);
       this->headers["host"] = this->url.host;
-      this->method = method;
+      this->method = method_;
       std::transform(this->method.begin(), this->method.end(), this->method.begin(), ::toupper);
       this->headers["user-agent"] = "YaHTTP v1.0";
     }; //<! Set some initial things for a request
@@ -301,10 +301,10 @@ public:
 
     void keyValuePair(const std::string &keyvalue, std::string &key, std::string &value); //<! key value pair parser helper
 
-    void initialize(T* target) {
+    void initialize(T* target_) {
       chunked = false; chunk_size = 0;
       bodybuf.str(""); minbody = 0; maxbody = 0;
-      pos = 0; state = 0; this->target = target; 
+      pos = 0; state = 0; this->target = target_;
       hasBody = false;
       buffer = "";
       this->target->initialize();
@@ -322,8 +322,8 @@ public:
     void finalize() {
       bodybuf.flush();
       if (ready()) {
-        strstr_map_t::iterator pos = target->headers.find("content-type");
-        if (pos != target->headers.end() && Utility::iequals(pos->second, "application/x-www-form-urlencoded", 32)) {
+        strstr_map_t::iterator cpos = target->headers.find("content-type");
+        if (cpos != target->headers.end() && Utility::iequals(cpos->second, "application/x-www-form-urlencoded", 32)) {
           target->postvars = Utility::parseUrlParameters(bodybuf.str());
         }
         target->body = bodybuf.str();

--- a/yahttp/router.cpp
+++ b/yahttp/router.cpp
@@ -27,7 +27,6 @@ namespace YaHTTP {
   bool Router::route(Request *req, THandlerFunction& handler) {
     std::map<std::string, TDelim> params;
     int pos1,pos2;
-    std::string pname;
     bool matched = false;
     std::string rname;
 


### PR DESCRIPTION
I'm trying to enable `-Wshadow` in `dnsdist` to prevent mistakes and it reports several shadowed variables in `YaHTTP`. All of these are harmless but it would make using `-Wshadow` easier.