### PR TITLE
Add missing `YaHTTP::isdigit()`, fix locale-enabled versions

### DIFF
--- a/yahttp/reqresp.cpp
+++ b/yahttp/reqresp.cpp
@@ -15,7 +15,15 @@ namespace YaHTTP {
   }
 
   bool isxdigit(char c, const std::locale& loc) {
-    return std::isspace(c, loc);
+    return std::isxdigit(c, loc);
+  }
+
+  bool isdigit(char c) {
+    return std::isdigit(c) != 0;
+  }
+
+  bool isdigit(char c, const std::locale& loc) {
+    return std::isdigit(c, loc);
   }
 
   bool isalnum(char c) {
@@ -23,7 +31,7 @@ namespace YaHTTP {
   }
 
   bool isalnum(char c, const std::locale& loc) {
-    return std::isspace(c, loc);
+    return std::isalnum(c, loc);
   }
 
   template <class T>

--- a/yahttp/utility.hpp
+++ b/yahttp/utility.hpp
@@ -9,6 +9,8 @@ namespace YaHTTP {
   bool isspace(char c, const std::locale& loc);
   bool isxdigit(char c);
   bool isxdigit(char c, const std::locale& loc);
+  bool isdigit(char c);
+  bool isdigit(char c, const std::locale& loc);
   bool isalnum(char c);
   bool isalnum(char c, const std::locale& loc);
 


### PR DESCRIPTION
* `YaHTTP::isdigit()` is used in `parse822` when `HAVE_TM_GMTOFF` is not defined.
* The locale-enabled versions looked like c/p errors.