### PR TITLE
cookie: Throw a ParseError exception on a invalid cookie

### DIFF
--- a/yahttp/cookie.hpp
+++ b/yahttp/cookie.hpp
@@ -74,7 +74,7 @@ namespace YaHTTP {
     void keyValuePair(const std::string &keyvalue, std::string &key, std::string &value) {
       size_t pos;
       pos = keyvalue.find("=");
-      if (pos == std::string::npos) throw "Not a Key-Value pair (cookie)";
+      if (pos == std::string::npos) throw ParseError("Not a Key-Value pair (cookie)");
       key = std::string(keyvalue.begin(), keyvalue.begin()+pos);
       value = std::string(keyvalue.begin()+pos+1, keyvalue.end());
     } //<! key value pair parser


### PR DESCRIPTION
Instead of a `const char*` exception.