### PR TITLE
Avoid calls to virtual functions from ct's.

### DIFF
--- a/yahttp/reqresp.hpp
+++ b/yahttp/reqresp.hpp
@@ -96,7 +96,7 @@ namespace YaHTTP {
     };
 
     HTTPBase() {
-      initialize();
+      HTTPBase::initialize();
     };
 
     virtual void initialize() {
@@ -196,7 +196,7 @@ public:
   /*! Response class, represents a HTTP Response document */
   class Response: public HTTPBase { 
   public:
-    Response() { initialize(); };
+    Response() { Response::initialize(); };
     Response(const HTTPBase& rhs): HTTPBase(rhs) {
       this->kind = YAHTTP_TYPE_RESPONSE;
     };
@@ -225,7 +225,7 @@ public:
   /* Request class, represents a HTTP Request document */
   class Request: public HTTPBase {
   public:
-    Request() { initialize(); };
+    Request() { Request::initialize(); };
     Request(const HTTPBase& rhs): HTTPBase(rhs) {
       this->kind = YAHTTP_TYPE_REQUEST;
     };


### PR DESCRIPTION
CodeQL says:

Call to virtual function initialize() which is overridden in Request.
If you intend to statically call this virtual function, it should be qualified with HTTPBase::.
Call to virtual function initialize() which is overridden in Response.
If you intend to statically call this virtual function, it should be qualified with HTTPBase::.

This rule finds calls to virtual functions from a constructor or
destructor that may resolve to a different function than was intended.
When instantiating a derived class, the resolution of a virtual
function call depends on the type that defines the constructor/destructor
that is currently running, not the class that is being instantiated.
This is to prevent the calling of functions in the derived class
that rely on fields declared in the derived class. The values of
such fields are undefined until the constructor of the derived class
is invoked after the constructor of the base class. Values declared
in the derived class are likewise destructed prior to invocation
of the destructor of the base class.