### PR TITLE
Better detection of whether C++11 features are available

### DIFF
--- a/yahttp/reqresp.hpp
+++ b/yahttp/reqresp.hpp
@@ -1,4 +1,4 @@
-#ifdef HAVE_CXX11
+#if __cplusplus >= 201103L
 #include <functional>
 #define HAVE_CPP_FUNC_PTR
 namespace funcptr = std;
@@ -72,7 +72,7 @@ namespace YaHTTP {
       size_t operator()(const HTTPBase *doc __attribute__((unused)), std::ostream& os, bool chunked) const {
         char buf[4096];
         size_t n,k;
-#ifdef HAVE_CXX11
+#if __cplusplus >= 201103L
         std::ifstream ifs(path, std::ifstream::binary);
 #else
         std::ifstream ifs(path.c_str(), std::ifstream::binary);

--- a/yahttp/router.cpp
+++ b/yahttp/router.cpp
@@ -99,7 +99,7 @@ namespace YaHTTP {
 
   void Router::printRoutes(std::ostream &os) {
     for(TRouteList::iterator i = routes.begin(); i != routes.end(); i++) {
-#ifdef HAVE_CXX11
+#if __cplusplus >= 201103L
       std::streamsize ss = os.width();
       std::ios::fmtflags ff = os.setf(std::ios::left);
       os.width(10);
@@ -123,7 +123,7 @@ namespace YaHTTP {
 
     bool found = false;
     for(TRouteList::iterator i = routes.begin(); !found && i != routes.end(); i++) {
-#ifdef HAVE_CXX11
+#if __cplusplus >= 201103L
       if (std::get<3>(*i) == name) { mask = std::get<1>(*i); method = std::get<0>(*i); found = true; }
 #else
       if (i->get<3>() == name) { mask = i->get<1>(); method = i->get<0>(); found = true; }

--- a/yahttp/router.hpp
+++ b/yahttp/router.hpp
@@ -2,7 +2,7 @@
 /* @file 
  * @brief Defines router class and support structures
  */
-#ifdef HAVE_CXX11
+#if __cplusplus >= 201103L
 #include <functional>
 #include <tuple>
 #define HAVE_CPP_FUNC_PTR


### PR DESCRIPTION
The previous version relied on having HAVE_CXX11 defined, which is not true when you are compiling with C++17, for example, even though the C++11 features are available (HAVE_CXX17 is defined but that does not help).