### PR TITLE
Prevent integer overflow on very large chunks

### DIFF
--- a/yahttp/reqresp.cpp
+++ b/yahttp/reqresp.cpp
@@ -1,5 +1,7 @@
 #include "yahttp.hpp"
 
+#include <limits>
+
 namespace YaHTTP {
 
   template class AsyncLoader<Request>;
@@ -177,6 +179,9 @@ namespace YaHTTP {
             throw ParseError("Unable to parse chunk size");
           }
           if (chunk_size == 0) { state = 3; break; } // last chunk
+          if (chunk_size > (std::numeric_limits<decltype(chunk_size)>::max() - 2)) {
+            throw ParseError("Chunk is too large");
+          }
         } else {
           int crlf=1;
           if (buffer.size() < static_cast<size_t>(chunk_size+1)) return false; // expect newline


### PR DESCRIPTION
If the chunk_size is very close to the maximum value of an integer, we trigger an integer overflow when checking if we have a trailing newline after the payload.

Reported by OSS-Fuzz as:
* https://oss-fuzz.com/testcase-detail/6439610474692608
 * https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=56804